### PR TITLE
Fix plugin name in rollup output for browsers use

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ export default [
   {
     input: 'src/index.js',
     output: {
-      name: 'markedBidi',
+      name: 'markedCustomHeadingId',
       file: 'lib/index.umd.js',
       format: 'umd',
     },


### PR DESCRIPTION
It used name `markedBidi` which is wrong.